### PR TITLE
Allow files with all tests skipped

### DIFF
--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -81,7 +81,7 @@ class Reader extends MetaProvider
      */
     public function hasResults()
     {
-        return $this->xml->count() > 0;
+        return count($this->xml->xpath('//testsuites') === 1;
     }
 
     /**

--- a/src/ParaTest/Logging/JUnit/Reader.php
+++ b/src/ParaTest/Logging/JUnit/Reader.php
@@ -81,7 +81,7 @@ class Reader extends MetaProvider
      */
     public function hasResults()
     {
-        return count($this->xml->xpath('//testsuites') === 1;
+        return count($this->xml->xpath('//testsuites')) === 1;
     }
 
     /**


### PR DESCRIPTION
Prevent files containing only skipped tests from causing the whole process to fail. This happens often with group exclusions, for example.
